### PR TITLE
Fix Chisel compilation warnings (W008, W004, W003)

### DIFF
--- a/bergamot/src/bergamot/core/record/CSRs.scala
+++ b/bergamot/src/bergamot/core/record/CSRs.scala
@@ -215,7 +215,7 @@ class CSRs extends Module {
   }
 
   when(io.trap.interruptTrigger) {
-    val delegation = interruptsReg.mideleg.value(pendingInterruptCode)
+    val delegation = interruptsReg.mideleg.value(pendingInterruptCode.pad(6))
     printf("Pending code = %d\n", pendingInterruptCode)
     when(!delegation) { // M-Handler
       io.trap.handlerPC := exceptionReg.interruptMLevel(io.trap.trapPC, pendingInterruptCode, io.trap.trapVal)
@@ -238,7 +238,7 @@ class CSRs extends Module {
   // Exception
   when(io.trap.exceptionTrigger) {
     // Delegation check
-    val delegation = exceptionReg.medeleg.value(io.trap.trapCode)
+    val delegation = exceptionReg.medeleg.value(io.trap.trapCode.pad(6))
 
     // Exceptions at M-Level will never be delegated to S-Level
     when(statusReg.privilege === PrivilegeType.M || !delegation) { // M-Handler

--- a/bergamot/src/bergamot/core/record/ROB.scala
+++ b/bergamot/src/bergamot/core/record/ROB.scala
@@ -51,19 +51,19 @@ class ROB(depth: Int) extends Module {
   // Table write logic
   when(io.robTableWrite.wen) {
     io.robTableWrite.entries.foreach { entry =>
-      table(entry.id).pc := entry.pc
-      table(entry.id).spec := entry.spec
-      table(entry.id).rd := entry.rd
-      table(entry.id).valid := entry.valid
-      table(entry.id).commit := false.B
+      table(entry.id(3, 0)).pc := entry.pc
+      table(entry.id(3, 0)).spec := entry.spec
+      table(entry.id(3, 0)).rd := entry.rd
+      table(entry.id(3, 0)).valid := entry.valid
+      table(entry.id(3, 0)).commit := false.B
     }
   }
 
   // Table commit logic
   io.robTableCommit.entries.foreach { entry =>
     when(entry.valid) {
-      table(entry.rd).executeResult := entry
-      table(entry.rd).commit := true.B
+      table(entry.rd(3, 0)).executeResult := entry
+      table(entry.rd(3, 0)).commit := true.B
     }
   }
 

--- a/bergamot/src/bergamot/core/record/StoreQueue.scala
+++ b/bergamot/src/bergamot/core/record/StoreQueue.scala
@@ -244,8 +244,10 @@ class StoreQueue(depth: Int) extends Module {
   io.retire.entries.foreach { entry =>
     when(entry.valid) {
       entry.id.foreach { id =>
-        queue(id).retire := true.B
-        queue(id).valid := true.B // Recovery bypass
+        // queue(id).retire := true.B
+        // queue(id).valid := true.B // Recovery bypass
+        queue(id(2, 0)).retire := true.B
+        queue(id(2, 0)).valid := true.B
       }
     }
   }

--- a/bergamot/src/bergamot/core/retire/InstructionRetire.scala
+++ b/bergamot/src/bergamot/core/retire/InstructionRetire.scala
@@ -84,8 +84,8 @@ class InstructionRetire(depth: Int) extends Module {
 
   // Retire entries
   private val retireEntries = VecInit(
-    io.robTableRetire.entries(io.retired.bits(30, 0) ## 0.U),
-    io.robTableRetire.entries(io.retired.bits(30, 0) ## 1.U)
+    io.robTableRetire.entries((io.retired.bits(30, 0) ## 0.U)(3, 0)),
+    io.robTableRetire.entries((io.retired.bits(30, 0) ## 1.U)(3, 0))
   )
 
   private val retireValid = retireEntries.map(item => item.commit || !item.valid)

--- a/bergamot/src/bergamot/utils/ChiselUtils.scala
+++ b/bergamot/src/bergamot/utils/ChiselUtils.scala
@@ -66,7 +66,7 @@ object ChiselUtils {
       * @return
       *   Zero
       */
-    def zero: T = 0.U.asTypeOf(x)
+    def zero: T = WireInit(0.U.asTypeOf(x))
 
     /** 0 as UInt
       *


### PR DESCRIPTION
This PR resolves several compilation warnings introduced by newer Chisel versions (specifically Chisel 3.6+). 
These warnings were cluttering the build output (during `mill bergamot.run`) and indicated potential future compatibility issues or may caused hardware logic risks.

<details>
<summary>Mill Process Outputs</summary>

```bash
$ mill bergamot.run
[33/46] bergamot.compile 
Compiling compiler interface...
[info] compiling 61 Scala sources to /home/ubuntu24/Desktop/Bergamot/out/bergamot/compile.dest/classes ...
[info] done compiling
[46/46] bergamot.run 

...

Bergamot: GEN 1 v1.000

Verilator 4.226 2022-08-31 rev v4.226

LLVM (http://llvm.org/):
  LLVM version 17.0.0git
  Optimized build.
CIRCT firtool-1.43.0
1. Standard Bergamot core
2. Verilator test core
Please select the core you want to export: 2
[warn] bergamot/src/bergamot/core/record/TLB.scala 145:14: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.request <> new TLBRequestIO().zero
[warn]              ^
[warn] bergamot/src/bergamot/core/record/TLB.scala 205:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.sma <> new SMAReaderIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/cache/Cache.scala 83:15: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.inWriter <> new SMAWriterIO().zero
[warn]               ^
[warn] bergamot/src/bergamot/cache/Cache.scala 84:15: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.inReader <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]               ^
[warn] bergamot/src/bergamot/cache/Cache.scala 85:16: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.outWriter <> new SMAWriterIO().zero
[warn]                ^
[warn] bergamot/src/bergamot/cache/Cache.scala 86:16: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.outReader <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]                ^
[warn] bergamot/src/bergamot/cache/Cache.scala 87:12: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.flush <> new FlushCacheIO().zero
[warn]            ^
[warn] bergamot/src/bergamot/core/fetch/Fetch.scala 145:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.itlb <> new TLBRequestIO().zero
[warn]           ^
[warn] bergamot/src/bergamot/core/fetch/Fetch.scala 201:13: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.icache <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]             ^
[warn] bergamot/src/bergamot/core/decode/Decode.scala 338:14: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.mapping <> new RegisterMappingIO().zero
[warn]              ^
[warn] bergamot/src/bergamot/core/decode/Decode.scala 485:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.enqs <> Vec(executeQueueWidth, new ExecuteQueueEnqueueIO()).zero
[warn]           ^
[warn] bergamot/src/bergamot/interconnect/CacheInterconnect.scala 38:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.in1 <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]          ^
[warn] bergamot/src/bergamot/interconnect/CacheInterconnect.scala 39:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.in2 <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]          ^
[warn] bergamot/src/bergamot/interconnect/CacheInterconnect.scala 40:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.out <> new CacheLineRequestIO(cacheCellDepth).zero
[warn]          ^
[warn] bergamot/src/bergamot/core/Core.scala 233:22: [W008] Return values of asTypeOf will soon be read-only
[warn]   iCache.io.inWriter <> new SMAWriterIO().zero
[warn]                      ^
[warn] bergamot/src/bergamot/core/Core.scala 234:23: [W008] Return values of asTypeOf will soon be read-only
[warn]   iCache.io.outWriter <> new SMAWriterIO().zero
[warn]                       ^
[warn] bergamot/src/bergamot/core/execute/ALU.scala 99:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.csr <> new CSRsReadIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/core/execute/Memory.scala 257:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.dtlb <> new TLBRequestIO().zero
[warn]           ^
[warn] bergamot/src/bergamot/core/execute/Memory.scala 358:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.sma <> new SMAReaderIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/core/execute/Memory.scala 398:12: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.alloc <> new StoreQueueAllocIO().zero
[warn]            ^
[warn] bergamot/src/bergamot/core/record/StoreQueue.scala 247:14: [W004] Dynamic index with width 64 is too wide for Vec of size 8 (expected index width 3).
[warn]         queue(id).retire := true.B
[warn]              ^
[warn] bergamot/src/bergamot/core/record/StoreQueue.scala 248:14: [W004] Dynamic index with width 64 is too wide for Vec of size 8 (expected index width 3).
[warn]         queue(id).valid := true.B // Recovery bypass
[warn]              ^
[warn] bergamot/src/bergamot/interconnect/SMAInterconnection.scala 116:9: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.in <> new SMAReaderIO().zero
[warn]         ^
[warn] bergamot/src/bergamot/interconnect/SMAInterconnection.scala 117:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.out1 <> new SMAReaderIO().zero
[warn]           ^
[warn] bergamot/src/bergamot/interconnect/SMAInterconnection.scala 118:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.out2 <> new SMAReaderIO().zero
[warn]           ^
[warn] bergamot/src/bergamot/core/retire/InstructionRetire.scala 87:30: [W004] Dynamic index with width 32 is too wide for Vec of size 16 (expected index width 4).
[warn]     io.robTableRetire.entries(io.retired.bits(30, 0) ## 0.U),
[warn]                              ^
[warn] bergamot/src/bergamot/core/retire/InstructionRetire.scala 88:30: [W004] Dynamic index with width 32 is too wide for Vec of size 16 (expected index width 4).
[warn]     io.robTableRetire.entries(io.retired.bits(30, 0) ## 1.U)
[warn]                              ^
[warn] bergamot/src/bergamot/core/retire/InstructionRetire.scala 101:11: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.trap <> new TrapRequestIO().zero
[warn]           ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 54:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.id).pc := entry.pc
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 55:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.id).spec := entry.spec
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 56:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.id).rd := entry.rd
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 57:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.id).valid := entry.valid
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 58:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.id).commit := false.B
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 65:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.rd).executeResult := entry
[warn]            ^
[warn] bergamot/src/bergamot/core/record/ROB.scala 66:12: [W004] Dynamic index with width 64 is too wide for Vec of size 16 (expected index width 4).
[warn]       table(entry.rd).commit := true.B
[warn]            ^
[warn] bergamot/src/bergamot/core/record/CSRs.scala 218:49: [W003] Dynamic index with width 5 is too small for extractee of width 64
[warn]     val delegation = interruptsReg.mideleg.value(pendingInterruptCode)
[warn]                                                 ^
[warn] bergamot/src/bergamot/core/record/CSRs.scala 241:48: [W003] Dynamic index with width 5 is too small for extractee of width 64
[warn]     val delegation = exceptionReg.medeleg.value(io.trap.trapCode)
[warn]                                                ^
[warn] bergamot/src/bergamot/bus/AXIMaster.scala 36:16: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.smaReader <> new SMAReaderIO().zero
[warn]                ^
[warn] bergamot/src/bergamot/bus/AXIMaster.scala 37:16: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.smaWriter <> new SMAWriterIO().zero
[warn]                ^
[warn] bergamot/src/bergamot/bus/AXIMaster.scala 38:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.axi <> new AXIMasterIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/interconnect/AXIInterconnect.scala 30:13: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.master <> new AXIMasterIO().zero
[warn]             ^
[warn] bergamot/src/bergamot/interconnect/AXIInterconnect.scala 31:23: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.slaves.foreach(_ <> new AXIMasterIO().zero)
[warn]                       ^
[warn] bergamot/src/bergamot/peripheral/VirtualUART.scala 29:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.axi <> new AXIMasterIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/peripheral/MachineTimer.scala 45:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.axi <> new AXIMasterIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/peripheral/ROM.scala 32:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.axi <> new AXIMasterIO().zero
[warn]          ^
[warn] bergamot/src/bergamot/peripheral/VirtualRAM.scala 31:10: [W008] Return values of asTypeOf will soon be read-only
[warn]   io.axi <> new AXIMasterIO().zero
[warn]          ^
[warn] There were 46 warning(s) during hardware elaboration.

----------------------------------------------
|       Thank you for using Bergamot!        |
| https://github.com/LoveLonelyTime/Bergamot |
|               BergamotCore                 |
|                                            |
----------------------------------------------
```

</details>

## Changes
- **[W008] Read-only return values**: Modified `bergamot.utils.ChiselUtils.zero` to use `WireInit(...)`. This ensures that the returned zero value is a writable Wire, fixing the issue where `asTypeOf` returns a read-only literal that cannot be used as a sink in bulk connections (`<>`). ([reference](https://www.chisel-lang.org/docs/explanations/warnings#w008-return-values-of-astypeof-will-soon-be-read-only))
- **[W004] Index too wide**: Applied bit extraction (e.g., `id(2, 0)`) in `StoreQueue`, `ROB`, and `InstructionRetire` to explicitly truncate indices to match the target Vec size. ([reference1](https://www.chisel-lang.org/docs/explanations/warnings#w004-dynamic-index-too-wide), [reference2](https://www.chisel-lang.org/docs/cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee-))
- **[W003] Index too narrow**: Added `.pad(width)` in `CSRs` to extend indices with leading zeros, ensuring they match the required width for `extractee` access. ([reference1](https://www.chisel-lang.org/docs/explanations/warnings#w004-dynamic-index-too-wide), [reference2](https://www.chisel-lang.org/docs/cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee-))

## Verification
Changes are verified by recompiling the project.
- **Compilation**: Ran `mill bergamot.run`. The build completed successfully with `0 warnings`.
```bash
$ mill bergamot.run
[33/46] bergamot.compile 
[info] compiling 1 Scala source to /home/ubuntu24/Desktop/Bergamot/out/bergamot/compile.dest/classes ...
[info] done compiling
[46/46] bergamot.run 
...
1. Standard Bergamot core
2. Verilator test core
Please select the core you want to export: 2

----------------------------------------------
|       Thank you for using Bergamot!        |
| https://github.com/LoveLonelyTime/Bergamot |
|               BergamotCore                 |
|                                            |
----------------------------------------------
```

- **Tests**: Added version 6.0.0 of `chiseltest` for local testing for running through `mill bergamot.test`. The floating-point unit tests passed successfully:

```bash
$ mill bergamot.test
Compiling /home/ubuntu24/Desktop/Bergamot/build.sc
[61/71] bergamot.test.compile 
[info] compiling 1 Scala source to /home/ubuntu24/Desktop/Bergamot/out/bergamot/test/compile.dest/classes ...
[info] done compiling
[71/71] bergamot.test.test 
FPTest:
FPTest
3245342720
- should pass
```