### PR TITLE
Support partial VCD waveform tracing to save disk space

### DIFF
--- a/simulator/sim_main.cpp
+++ b/simulator/sim_main.cpp
@@ -108,6 +108,21 @@ int main(int argc, char **argv)
         VL_PRINTF(P_WARN "No device tree file specified!\n");
     }
 
+    vluint64_t trace_start = 0;
+    vluint64_t trace_end = -1; // means infinite
+
+    flag = Verilated::commandArgsPlusMatch("trace_start");
+    if (flag && strncmp(flag, "+trace_start", 12) == 0)
+    {
+        trace_start = strtoul(&flag[13], NULL, 10);
+    }
+
+    flag = Verilated::commandArgsPlusMatch("trace_end");
+    if (flag && strncmp(flag, "+trace_end", 10) == 0)
+    {
+        trace_end = strtoul(&flag[11], NULL, 10);
+    }
+
     // Create verilator top
     VVerilatorTestCore *top = new VVerilatorTestCore;
 #ifdef VM_TRACE
@@ -186,7 +201,7 @@ int main(int argc, char **argv)
         // if (top->io_debug_hit) {
 #ifdef VM_TRACE
         // Dump trace data for this cycle
-        if (tfp)
+        if (tfp && main_time >= trace_start && main_time <= trace_end)
             tfp->dump(main_time);
 #endif
         // }


### PR DESCRIPTION
When simulating long-running workloads, such as booting Linux via OpenSBI which may exceed large cycles, resulting in the entire waveform from cycle 0 generates massive VCD files. This leads to `No space left on device` errors.

This PR introduces the ability to record partial VCD waveforms during Verilator simulation by adding `+trace_start` and `+trace_end` arguments to `sim_main.cpp` in order to specify a target time window for waveform dumping


## Example
```bash
# Tracing from start and no specific stop time
$ ./obj_dir/VVerilatorTestCore +trace +Bfw_payload.bin +Dsim_dt.dtb

# Tracing from cycle 17000000 to cycle 22500000
$ ./obj_dir/VVerilatorTestCore +trace +trace_start=17000000 +trace_end=22500000 +Bfw_payload.bin +Dsim_dt.dtb
```
